### PR TITLE
Add a builtin for calling a verb by verb number

### DIFF
--- a/src/db.h
+++ b/src/db.h
@@ -469,6 +469,12 @@ extern db_verb_handle db_find_defined_verb(Objid oid, const char *verb,
 				 * leave the handle intact.
 				 */
 
+extern Var db_find_matching_verb_numbers(Objid oid, const char *vname);
+				/* Returns a list of 1-indexed verb numbers
+				 * found defined on OID with a name matching
+				 * VERB.
+				 */
+
 extern db_verb_handle db_find_indexed_verb(Objid oid, unsigned index);
 				/* Returns a handle on the 1-based INDEX'th
 				 * verb defined on OID.  The `ptr' in the

--- a/src/db_verbs.c
+++ b/src/db_verbs.c
@@ -575,6 +575,31 @@ db_find_defined_verb(Objid oid, const char *vname, int allow_numbers)
     return vh;
 }
 
+/*
+ * Get all verb numbers on the object that match the verb name.
+ */
+Var
+db_find_matching_verb_numbers(Objid oid, const char *vname)
+{
+    Object *o = dbpriv_find_object(oid);
+    Verbdef *v;
+    int i;
+    Var tempresult;
+    Var results = new_list(0);
+
+    tempresult.type = TYPE_INT;
+
+    for (i = 0, v = o->verbdefs; v; v = v->next, i++) {
+        if (verbcasecmp(v->name, vname)) {
+            /* Add this to the matches. */
+            tempresult.v.num = i + 1;
+            results = listappend(results, tempresult);
+        }
+    }
+
+    return results;
+}
+
 db_verb_handle
 db_find_indexed_verb(Objid oid, unsigned index)
 {

--- a/src/execute.c
+++ b/src/execute.c
@@ -3043,7 +3043,7 @@ bf_call_verb(Var arglist, Byte next, void *vdata, Objid progr)
 
 /*
  * Call a verb via verb number.
- * call_verb_index(OBJ vloc, INT vnum, STR vname, LIST vargs, [, OBJ this]) => ANY
+ * call_verb_index(OBJ vloc, INT vnum, STR vname, LIST vargs, [, OBJ this[, OBJ permissions]]) => ANY
  */
 static package
 bf_call_verb_index(Var arglist, Byte next, void *vdata, Objid progr)
@@ -3061,7 +3061,7 @@ bf_call_verb_index(Var arglist, Byte next, void *vdata, Objid progr)
         return make_error_pack(E_INVIND);
     }
 
-    if (arglist.v.list[0].v.num == 5) {
+    if (arglist.v.list[0].v.num >= 5) {
         new_this = arglist.v.list[5].v.obj;
     } else {
         new_this = RUN_ACTIV.this;
@@ -3074,6 +3074,11 @@ bf_call_verb_index(Var arglist, Byte next, void *vdata, Objid progr)
     }
 
     unsigned verb_index = arglist.v.list[2].v.num;
+
+    if (arglist.v.list[0].v.num >= 6) {
+        /* Drop permissions too. */
+        RUN_ACTIV.progr = arglist.v.list[6].v.obj;
+    }
 
     enum error e = call_verb_index(where, verb_index, new_this, arglist.v.list[3].v.str, arglist.v.list[4]);
 
@@ -3197,8 +3202,8 @@ register_execute(void)
     register_function("pass", 0, -1, bf_pass);
     register_function("call_verb", 3, 4, bf_call_verb, 
 	TYPE_OBJ, TYPE_STR, TYPE_LIST, TYPE_OBJ);
-    register_function("call_verb_index", 4, 5, bf_call_verb_index,
-        TYPE_OBJ, TYPE_INT, TYPE_STR, TYPE_LIST, TYPE_OBJ);
+    register_function("call_verb_index", 4, 6, bf_call_verb_index,
+        TYPE_OBJ, TYPE_INT, TYPE_STR, TYPE_LIST, TYPE_OBJ, TYPE_OBJ);
     register_function("set_task_perms", 1, 1, bf_set_task_perms, TYPE_OBJ);
     register_function("caller_perms", 0, 0, bf_caller_perms);
     register_function("callers", 0, 1, bf_callers, TYPE_ANY);

--- a/src/execute.c
+++ b/src/execute.c
@@ -775,6 +775,34 @@ _call_verb(Objid this, const char *vname, Var THIS, Var args, int do_pass)
     return _call_verb_handle(this, h, vname, THIS, args);
 }
 
+enum error
+_call_verb_index(Objid where, unsigned verb_index, Objid this, const char *vname, Var THIS, Var args)
+{
+    db_verb_handle h;
+
+    if (!valid(where)) {
+        return E_INVIND;
+    }
+    h = db_find_indexed_verb(where, verb_index);
+    if (!h.ptr) {
+        return E_VERBNF;
+    } else if (!push_activation()) {
+        return E_MAXREC;
+    }
+
+    return _call_verb_handle(this, h, vname, THIS, args);
+}
+
+enum error
+call_verb_index(Objid where, unsigned verb_index, Objid this, const char *vname, Var args)
+{
+    Var THIS;
+
+    THIS.type = TYPE_OBJ;
+    THIS.v.obj = this;
+    return _call_verb_index(where, verb_index, this, vname, THIS, args);
+}
+
  enum error
  call_verb(Objid this, const char *vname, Var args, int do_pass)
  {
@@ -3013,6 +3041,52 @@ bf_call_verb(Var arglist, Byte next, void *vdata, Objid progr)
    }
 }
 
+/*
+ * Call a verb via verb number.
+ * call_verb_index(OBJ vloc, INT vnum, STR vname, LIST vargs, [, OBJ this]) => ANY
+ */
+static package
+bf_call_verb_index(Var arglist, Byte next, void *vdata, Objid progr)
+{
+    Objid where = arglist.v.list[1].v.obj;
+    Objid new_this;
+
+    if (!is_wizard(progr)) {
+        free_var(arglist);
+        return make_error_pack(E_PERM);
+    }
+
+    if (!valid(where)) {
+        free_var(arglist);
+        return make_error_pack(E_INVIND);
+    }
+
+    if (arglist.v.list[0].v.num == 5) {
+        new_this = arglist.v.list[5].v.obj;
+    } else {
+        new_this = RUN_ACTIV.this;
+    }
+
+    if (arglist.v.list[2].v.num < 1) {
+        /* Don't bother looking for 0 or negative verb numbers. */
+        free_var(arglist);
+        return make_error_pack(E_VERBNF);
+    }
+
+    unsigned verb_index = arglist.v.list[2].v.num;
+
+    enum error e = call_verb_index(where, verb_index, new_this, arglist.v.list[3].v.str, arglist.v.list[4]);
+
+    if (e == E_NONE) {
+        arglist.v.list[4] = zero; /* avoid double-free */
+        free_var(arglist);
+        return tail_call_pack();
+    } else {
+        free_var(arglist);
+        return make_error_pack(e);
+    }
+}
+
 static package
 bf_set_task_perms(Var arglist, Byte next, void *vdata, Objid progr)
 {				/* (player) */
@@ -3123,6 +3197,8 @@ register_execute(void)
     register_function("pass", 0, -1, bf_pass);
     register_function("call_verb", 3, 4, bf_call_verb, 
 	TYPE_OBJ, TYPE_STR, TYPE_LIST, TYPE_OBJ);
+    register_function("call_verb_index", 4, 5, bf_call_verb_index,
+        TYPE_OBJ, TYPE_INT, TYPE_STR, TYPE_LIST, TYPE_OBJ);
     register_function("set_task_perms", 1, 1, bf_set_task_perms, TYPE_OBJ);
     register_function("caller_perms", 0, 0, bf_caller_perms);
     register_function("callers", 0, 1, bf_callers, TYPE_ANY);

--- a/src/execute.c
+++ b/src/execute.c
@@ -659,17 +659,12 @@ free_activation(activation a, char data_too)
   does not change the vm in case of any error **/
 
 enum error
-_call_verb_handle(Objid this, db_verb_handle h, const char *vname, Var THIS, Var args, int do_pass)
+_call_verb_handle(Objid this, db_verb_handle h, const char *vname, Var THIS, Var args)
 {
     /* if call succeeds, args will be consumed.  If call fails, args
        will NOT be consumed  -- it must therefore be freed by caller */
     /* vname will never be consumed */
     /* THIS will never be consumed */
-
-    /* do_pass:
-     *   1 - normal pass, find this verb on parent of this.
-     *   2 - bf_call pass, go to entirely new verb, preserve this.
-     *  */
 
     /* will only return E_MAXREC, E_INVIND, E_VERBNF, or E_NONE */
     /* returns an error if there is one, and does not change the vm in that
@@ -746,6 +741,10 @@ _call_verb_handle(Objid this, db_verb_handle h, const char *vname, Var THIS, Var
 enum error
 _call_verb(Objid this, const char *vname, Var THIS, Var args, int do_pass)
 {
+    /* do_pass:
+     *   1 - normal pass, find this verb on parent of this.
+     *   2 - bf_call pass, go to entirely new verb, preserve this.
+     *  */
     Objid where;
     db_verb_handle h;
 
@@ -773,7 +772,7 @@ _call_verb(Objid this, const char *vname, Var THIS, Var args, int do_pass)
         return E_MAXREC;
     }
 
-    return _call_verb_handle(this, h, vname, THIS, args, do_pass);
+    return _call_verb_handle(this, h, vname, THIS, args);
 }
 
  enum error

--- a/src/verbs.c
+++ b/src/verbs.c
@@ -101,6 +101,29 @@ bf_has_callable_verb(Var arglist, Byte next, void *vdata, Objid progr)
     }
 }
 
+/*
+ * Return the verb numbers of all matching verbs on the given object.
+ * verb_matches(OBJ object, STR vname) => {INT vnum, ...}
+ */
+static package
+bf_verb_matches(Var arglist, Byte next, void *vdata, Objid progr)
+{
+    Objid oid = arglist.v.list[1].v.obj;
+
+    if (!valid(oid)) {
+        free_var(arglist);
+        return make_error_pack(E_INVARG);
+    } else if (!db_object_allows(oid, progr, FLAG_READ)) {
+        /* They don't have permission to read this object. */
+        free_var(arglist);
+        return make_error_pack(E_PERM);
+    } else {
+        Var result = db_find_matching_verb_numbers(oid, arglist.v.list[2].v.str);
+        free_var(arglist);
+        return make_var_pack(result);
+    }
+}
+
 static enum error
 validate_verb_info(Var v, Objid * owner, unsigned *flags, const char **names)
 {
@@ -589,6 +612,7 @@ register_verbs(void)
 {
     register_function("verbs", 1, 1, bf_verbs, TYPE_OBJ);
     register_function("has_callable_verb", 2, 2, bf_has_callable_verb, TYPE_OBJ, TYPE_STR);
+    register_function("verb_matches", 2, 2, bf_verb_matches, TYPE_OBJ, TYPE_STR);
     register_function("verb_info", 2, 2, bf_verb_info, TYPE_OBJ, TYPE_ANY);
     register_function("set_verb_info", 3, 3, bf_set_verb_info,
 		      TYPE_OBJ, TYPE_ANY, TYPE_LIST);


### PR DESCRIPTION
When a verb match is ambiguous, the engine allows the database code to handle verb lookup.

However, in the case where there may be multiple verbs of the same name, there is no way to disambiguate them.

For example, consider a book with the following verbs:

- `book:turn this to any`
- `book:turn this`

If you have a single book, the engine can find both verbs just fine, but if you have two books, the database code will have to find the proper match.

However, there previously was no way to call the second verb, as `turn` will match the first, and there was no way to call it via verb number.

This adds a new builtin to do so, with similar semantics to `call_verb`:

```
  call_verb_index(OBJ verb_location,
                  INT verb_number,
                  STR verb_name,
                  LIST verb_arguments,
                  [, OBJ this
                  [, OBJ permissions]])
    => ANY
```

The `verb_location` and `verb_number` will be used to look up the verb, `verb_name` is used to set the verb name within the call, and if not supplied, as with `call_verb`, `this` defaults to the caller.

If `permissions` is given, it will be treated as if you'd called `set_task_perms(permissions)`, which will modify the current stack frame's privileges, since you can't drop permissions to non-wizardly ones and still call `call_verb_index()`.