### PR TITLE
Improve the crypt() builtin

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -22,6 +22,12 @@ indent_style = tab
 indent_style = space
 indent_size = 2
 
+# Settings for autoconf.
+[*.ac]
+# Indent with two spaces.
+indent_style = space
+indent_size = 2
+
 # Settings for C files.
 [*.{c,h}]
 # Indent with four spaces.

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ Makefile
 Makefile.in
 aclocal.m4
 autom4te.cache/
+build-aux/
 compile
 config.h
 config.h.in

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ Source code for the HellCore project, a fork of LambdaMOO.
 * bison
 * gcc
 * gperf
+* libcrypt (any compliant implementation, libxcrypt is a good option if your
+    glibc no longer supplies a libcrypt and you're on a distro/in an environment
+    that for some reason hasn't already added a replacement)
 * libstdc++
 * make
 * sed
@@ -54,6 +57,49 @@ run
 ```shell
 ./autogen.sh && ./configure && make
 ```
+
+### Troubleshooting
+
+If you're having trouble building after updating this repository, parts of the
+build system may be out of date.
+
+Before trying to build again, try running
+```shell
+./autogen.sh && make distclean
+```
+
+### Optional Features
+
+A few features can optionally be enabled/disabled when compiling.
+
+If you use `./build.sh`, you should get a reasonable set of defaults.
+
+#### More Secure Password Hashes
+
+If you have a more modern libcrypt implementation, such as libxcrypt, and it
+provides `crypt_gensalt`, the moo will use this to generate more secure and
+modern password hashes.
+
+This means that if your database uses the `crypt()` builtin to store passwords,
+it will be able to use a format which is far more secure, as the old password
+format can be be cracked fairly quickly on modern computers if someone can
+manage to get a copy of your database.
+
+This should generally be fairly backwards-compatible with older databases, and
+old password hashes will still be read fine after this change, but new passwords
+hashed will be more secure.
+
+The new password hashes won't be properly understood by older versions of the
+`crypt()` builtin, and may not be understood by versions of the moo built
+without this feature, however, so if you want to disable the more secure hashes
+to ensure that your database can be used with older versions of the moo binary,
+you can pass `--disable-crypt-gensalt` to `./configure` when building.
+
+Note that if your distro has built your libcrypt provider without support for
+old, insecure hashes, regardless of whether you have this feature enabled or
+not, you may need to, e.g., install via your package manager a build of
+libxcrypt which has support for insecure hashes enabled in order to authenticate
+against password hashes from older databases.
 
 ### USE AT YOUR OWN RISK. I DENY RESPONSIBILITY FOR:
 * Spontaneous hairy nose

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,6 +1,20 @@
 #!/bin/sh
 
+# Die on failures.
+set -e
+
 # Regenerate the build system.
 # You probably shouldn't need to modify this.
 
+# Make sure we're in the project directory.
+cd "$(dirname "$0")"
+
+# Make sure we've got an m4 macro directory.
+mkdir -p m4 build-aux
+
+# If we use macros available on the system, copy them into our m4 directory if
+# we don't have them, or if the system has a newer version.
+aclocal --install
+
+# Regenerate our build system.
 autoreconf --install --force

--- a/configure.ac
+++ b/configure.ac
@@ -81,8 +81,20 @@ AC_PROG_SED
 AC_SEARCH_LIBS([atan2], [m])
 
 
+# Figure out what crypt we have.
+
+# Find a crypt.h.
+AC_CHECK_HEADERS([crypt])
+
 # Link the crypt library.
-AC_SEARCH_LIBS([crypt], [crypt])
+# If we don't find a valid crypt() implementation, be loud and give up.
+# We can technically use the no-op crypt that's just duplicating the string, but
+# failing to an insecure mode without making the user explicitly request/allow
+# it feels wrong.
+AC_SEARCH_LIBS([crypt],
+               [crypt],
+               [],
+               AC_MSG_ERROR([cannot find a crypt() implementation]))
 
 
 # Generate the configure script.

--- a/configure.ac
+++ b/configure.ac
@@ -84,7 +84,7 @@ AC_SEARCH_LIBS([atan2], [m])
 # Figure out what crypt we have.
 
 # Find a crypt.h.
-AC_CHECK_HEADERS([crypt])
+AC_CHECK_HEADERS([crypt.h])
 
 # Link the crypt library.
 # If we don't find a valid crypt() implementation, be loud and give up.

--- a/configure.ac
+++ b/configure.ac
@@ -96,6 +96,18 @@ AC_SEARCH_LIBS([crypt],
                [],
                [AC_MSG_ERROR([cannot find a crypt implementation])])
 
+# Check if we have the more modern helper function to generate a salt.
+# If we do, we can get the benefits of whatever the best algorithm our crypt
+# implementation has, without needing to know what algorithm it is or how we
+# should generate a salt.
+# If we don't find it, we fall back on the less secure DES crypt().
+AC_SEARCH_LIBS([crypt_gensalt],
+               [crypt xcrypt],
+               [AC_DEFINE([HAVE_CRYPT_GENSALT],
+                          1,
+                          [Define to 1 if crypt_gensalt is available.])],
+               [AC_MSG_WARN([using insecure DES crypt salts as crypt_gensalt is unavailable])])
+
 
 # Generate the configure script.
 # (There probably shouldn't be any autoconf things after this.)

--- a/configure.ac
+++ b/configure.ac
@@ -96,6 +96,14 @@ AC_SEARCH_LIBS([crypt],
                [],
                [AC_MSG_ERROR([cannot find a crypt implementation])])
 
+# Give a way to disable crypt_gensalt usage, in case someone wants to stick with
+# the old DES crypt.
+AC_ARG_ENABLE([crypt-gensalt],
+              [AS_HELP_STRING([--disable-crypt-gensalt],
+                              [disable support for newer crypt algorithms])],
+              [],
+              [enable_crypt_gensalt=default])
+
 # Check if we have the more modern helper function to generate a salt.
 # If we do, we can get the benefits of whatever the best algorithm our crypt
 # implementation has, without needing to know what algorithm it is or how we
@@ -103,10 +111,38 @@ AC_SEARCH_LIBS([crypt],
 # If we don't find it, we fall back on the less secure DES crypt().
 AC_SEARCH_LIBS([crypt_gensalt],
                [crypt xcrypt],
-               [AC_DEFINE([HAVE_CRYPT_GENSALT],
-                          1,
-                          [Define to 1 if crypt_gensalt is available.])],
-               [AC_MSG_WARN([using insecure DES crypt salts as crypt_gensalt is unavailable])])
+               [crypt_gensalt_available=yes],
+               [crypt_gensalt_available=no])
+
+# Validate our crypt_gensalt setup.
+if test "x$enable_crypt_gensalt" = "xdefault"; then
+  # We should try to use crypt_gensalt, but it's only a warning if we can't.
+  use_crypt_gensalt="$crypt_gensalt_available"
+  if test "x$crypt_gensalt_available" = "xno"; then
+    # Warn that we could be using more secure salts.
+    AC_MSG_WARN([using insecure DES crypt salts as crypt_gensalt is unavailable])
+  fi
+elif test "x$enable_crypt_gensalt" = "xyes"; then
+  # They explicitly requested support, so die if we didn't find it.
+  if test "x$crypt_gensalt_available" = "xno"; then
+    AC_MSG_ERROR([crypt_gensalt is unavailable but newer hash salts were requested])
+  fi
+  use_crypt_gensalt=yes
+elif test "x$enable_crypt_gensalt" = "xno"; then
+  # Stick with the legacy salts.
+  # We don't need to warn about crypt_gensalt being unavailable, since we were
+  # asked to exclude it anyway.
+  use_crypt_gensalt=no
+else
+  AC_MSG_ERROR([unrecognized value '$enable_crypt_gensalt' for --enable-crypt-gensalt])
+fi
+
+# If we should use crypt_gensalt, let our code know.
+if test "x$use_crypt_gensalt" = "xyes"; then
+AC_DEFINE([USE_CRYPT_GENSALT],
+          1,
+          [Define to 1 if crypt_gensalt should be used.])
+fi
 
 
 # Generate the configure script.

--- a/configure.ac
+++ b/configure.ac
@@ -92,9 +92,9 @@ AC_CHECK_HEADERS([crypt.h])
 # failing to an insecure mode without making the user explicitly request/allow
 # it feels wrong.
 AC_SEARCH_LIBS([crypt],
-               [crypt],
+               [crypt xcrypt],
                [],
-               AC_MSG_ERROR([cannot find a crypt() implementation]))
+               [AC_MSG_ERROR([cannot find a crypt implementation])])
 
 
 # Generate the configure script.

--- a/configure.ac
+++ b/configure.ac
@@ -19,10 +19,19 @@ AC_INIT([HellCore],
         [https://github.com/diatomic-ge/HellCore])
 
 
+# Put extra build tools in the build-aux directory to keep things tidy.
+AC_CONFIG_AUX_DIR([build-aux])
+
+
 # Initialize automake.
 # foreign:      Tell automake not to expect the standard GNU files (NEWS,
 #               AUTHORS, etc.), and not to error when it doesn't find them.
 AM_INIT_AUTOMAKE([foreign])
+
+
+# Keep all our autoconf macros in the m4 directory.
+AC_CONFIG_MACRO_DIRS([m4])
+
 
 # By default, just show what's being compiled while building, rather than the
 # whole command.

--- a/flake.nix
+++ b/flake.nix
@@ -69,7 +69,9 @@
             # A more modern libcrypt.
             # This is necessary, since libcrypt might be being phased out of
             # glibc, and we won't get a libcrypt for free from stdenv.
-            libxcrypt
+            # We enable all hashes, so that databases with old DES hashes don't
+            # break.
+            (libxcrypt.override { enableHashes = "all"; })
           ];
 
           # Extra flags to pass to ./configure.

--- a/flake.nix
+++ b/flake.nix
@@ -65,6 +65,11 @@
 
             # The gperf perfect hash generator for recognizing keywords.
             gperf
+
+            # A more modern libcrypt.
+            # This is necessary, since libcrypt might be being phased out of
+            # glibc, and we won't get a libcrypt for free from stdenv.
+            libxcrypt
           ];
 
           # Extra flags to pass to ./configure.

--- a/src/list.c
+++ b/src/list.c
@@ -15,6 +15,8 @@
     Pavel@Xerox.Com
  *****************************************************************************/
 
+#include <config.h>
+
 #include "my-ctype.h"
 #include "my-string.h"
 
@@ -37,6 +39,8 @@
 #include "unparse.h"
 #include "utils.h"
 #include "hash_lookup.h"
+
+#include <errno.h>
 
 #if HAVE_CRYPT_H
 #include <crypt.h>
@@ -633,28 +637,96 @@ bf_strsub(Var arglist, Byte next, void *vdata, Objid progr)
     }
 }
 
+/*
+ * Generate a DES crypt salt.
+ */
+#if !USE_CRYPT_GENSALT
+static char*
+make_des_crypt_salt()
+{
+    static char salt[3];
+    static char saltstuff[] =
+        "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789./";
+
+    salt[0] = saltstuff[RANDOM() % (int) strlen(saltstuff)];
+    salt[1] = saltstuff[RANDOM() % (int) strlen(saltstuff)];
+    salt[2] = '\0';
+
+    return salt;
+}
+#endif
+
 static package
 bf_crypt(Var arglist, Byte next, void *vdata, Objid progr)
 {				/* (string, [salt]) */
     Var r;
 
-    char salt[3];
-    static char saltstuff[] =
-    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789./";
-    extern const char *crypt(const char *, const char *);
+    const char* salt;
+    const char* hash;
+    int generated_salt = 0;
 
     if (arglist.v.list[0].v.num == 1 || strlen(arglist.v.list[2].v.str) < 2) {
-	salt[0] = saltstuff[RANDOM() % (int) strlen(saltstuff)];
-	salt[1] = saltstuff[RANDOM() % (int) strlen(saltstuff)];
-    } else {
-	salt[0] = arglist.v.list[2].v.str[0];
-	salt[1] = arglist.v.list[2].v.str[1];
-    }
-    salt[2] = '\0';
-    r.type = TYPE_STR;
-    r.v.str = str_dup(crypt(arglist.v.list[1].v.str, salt));
+        /* Generate a salt. */
+        generated_salt = 1;
+#if USE_CRYPT_GENSALT
+        /*
+         * Ask crypt_gensalt for a salt for the best hash with default cost.
+         * We are explicitly allowed to give this pointer to crypt and not worry
+         * about freeing or anything.
+         */
+        salt = crypt_gensalt(NULL, 0, NULL, 0);
 
+        if (salt == NULL) {
+            /* Log whyever we failed to generate a salt and raise an error. */
+            log_perror("Failed to generate crypt salt");
+            free_var(arglist);
+            return make_raise_pack(E_QUOTA, "Failed to generate a crypt() salt", zero);
+        }
+#else
+        /* Use a legacy salt. */
+        salt = make_des_crypt_salt();
+#endif
+    } else {
+        /* Use our second argument as a salt. */
+        salt = arglist.v.list[2].v.str;
+    }
+
+    /* Hash our input. */
+    hash = crypt(arglist.v.list[1].v.str, salt);
+
+    /* Free our arguments since we don't need them later. */
     free_var(arglist);
+
+    if (hash == NULL) {
+        /* Crypt failed for some reason. */
+        if (errno == EINVAL) {
+            /* We had an invalid salt. */
+            if (generated_salt) {
+                /* Log a bit more specifically. */
+                log_perror("crypt rejected generated salt");
+            } else {
+                /*
+                 * Don't log user-supplied salts being wrong, but do tell the
+                 * user that explicitly since they were the one to supply it.
+                 */
+                return make_raise_pack(E_INVARG, "Invalid crypt() salt", zero);
+            }
+        } else {
+            /* Log whatever other error this is. */
+            log_perror("crypt failed");
+        }
+        /* Report the error. */
+        return make_raise_pack(E_QUOTA, "Call to crypt() failed", zero);
+    } else if (hash[0] == '*') {
+        /* For an unspecified reason, hashing failed. */
+        errlog("crypt returned an invalid/error hash starting with *");
+        return make_raise_pack(E_QUOTA, "Call to crypt() failed", zero);
+    }
+
+    /* Build up our return object. */
+    r.type = TYPE_STR;
+    r.v.str = str_dup(hash);
+
     return make_var_pack(r);
 }
 

--- a/src/list.c
+++ b/src/list.c
@@ -38,6 +38,10 @@
 #include "utils.h"
 #include "hash_lookup.h"
 
+#if HAVE_CRYPT_H
+#include <crypt.h>
+#endif
+
 #define TRY_REALLOC_TRICKS 1
 
 Var
@@ -634,7 +638,6 @@ bf_crypt(Var arglist, Byte next, void *vdata, Objid progr)
 {				/* (string, [salt]) */
     Var r;
 
-#if HAVE_CRYPT
     char salt[3];
     static char saltstuff[] =
     "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789./";
@@ -650,10 +653,6 @@ bf_crypt(Var arglist, Byte next, void *vdata, Objid progr)
     salt[2] = '\0';
     r.type = TYPE_STR;
     r.v.str = str_dup(crypt(arglist.v.list[1].v.str, salt));
-#else				/* !HAVE_CRYPT */
-    r.type = TYPE_STR;
-    r.v.str = str_ref(arglist.v.list[1].v.str);
-#endif
 
     free_var(arglist);
     return make_var_pack(r);

--- a/src/oldconfig.h
+++ b/src/oldconfig.h
@@ -166,7 +166,6 @@
  * system provides the named functions.
  */
 
-#define HAVE_CRYPT 1
 #define HAVE_MATHERR 1
 #define HAVE_MKFIFO 1
 #define HAVE_REMOVE 1


### PR DESCRIPTION
The `crypt()` builtin currently uses DES for hashing passwords, which is very insecure.

If available and enabled, we now use `crypt_gensalt()` to make a usable salt for whatever algorithm the library supplying `crypt()` thinks is strongest.

Since this is provided by a fair few newer libcrypt libraries, such as libxcrypt and crypt_blowfish, it's fairly widespread.

Additionally, glibc recently removed its libcrypt implementation, so many distros are now using a more modern libcrypt supplied by a project focused on cryptography, like libxcrypt, making it more likely to be available, and making it necessary to ensure libcrypt is properly found and linked if needed.

In short, this should make it fairly easy to have more secure password hashes, and at least in databases I have, it should just work without any major issues or changes needed to the database code.

If someone wants to explicitly stick with legacy DES hashes only, to keep a database compatible with older versions of the engine, `--disable-crypt-gensalt` can be passed to `configure` to disable the new hash salts.