### PR TITLE
Fix bytecode generation for call_verb and call_verb_index

### DIFF
--- a/src/code_gen.c
+++ b/src/code_gen.c
@@ -19,6 +19,7 @@
 
 #include "ast.h"
 #include "exceptions.h"
+#include "functions.h"
 #include "opcode.h"
 #include "program.h"
 #include "storage.h"
@@ -479,6 +480,25 @@ exit_loop(State * state)
 
 
 static void
+emit_call_bi_func_op(Opcode op, unsigned func, State * state)
+{
+    emit_byte(op, state);
+
+#ifdef BYTECODE_REDUCE_REF
+    /*
+     * Only record this in the push map if it's specifically a builtin which
+     * requires the VR variables (e.g. dobj), keeping similar semantics around
+     * preventing them from being cleared similar to OP_CALL_VERB.
+     */
+    if (bi_function_requires_bi_variables(func)) {
+        state->pushmap[state->num_bytes - 1] = OP_BI_FUNC_CALL;
+    }
+#endif /* BYTECODE_REDUCE_REF */
+
+    emit_byte(func, state);
+}
+
+static void
 emit_call_verb_op(Opcode op, State * state)
 {
     emit_byte(op, state);
@@ -752,8 +772,7 @@ generate_expr(Expr * expr, State * state)
 	break;
     case EXPR_CALL:
 	generate_arg_list(expr->e.call.args, state);
-	emit_byte(OP_BI_FUNC_CALL, state);
-	emit_byte(expr->e.call.func, state);
+	emit_call_bi_func_op(OP_BI_FUNC_CALL, expr->e.call.func, state);
 	break;
     case EXPR_VERB:
 	generate_expr(expr->e.verb.obj, state);
@@ -1259,15 +1278,23 @@ stmt_to_code(Stmt * stmt, GState * gstate)
 		 * a ref to `args' during the called verb.
 		 */
 		varbits = ~0U;
-	    } else if (state.pushmap[old_i] == OP_CALL_VERB) {
-		/*
-		 * Verb calls implicitly pass the VR variables (dobj,
-		 * dobjstr, player, etc).  They can't be clear at the
-		 * time of a verbcall.
-		 */
-		varbits &= NON_VR_VAR_MASK;
-	    }
-	}
+            } else if (state.pushmap[old_i] == OP_CALL_VERB ||
+                    state.pushmap[old_i] == OP_BI_FUNC_CALL) {
+                /*
+                 * Verb calls implicitly pass the VR variables (dobj,
+                 * dobjstr, player, etc).  They can't be clear at the
+                 * time of a verbcall.
+                 *
+                 * If it's OP_BI_FUNC_CALL, this is a signal from
+                 * emit_call_bi_func_op that this is a builtin which may require
+                 * the VR variables, and should be treated the same.
+                 *
+                 * Nothing else should (at the moment) put OP_BI_FUNC_CALL into
+                 * the pushmap.
+                 */
+                varbits &= NON_VR_VAR_MASK;
+            }
+        }
     }
     myfree(bbd, M_CODE_GEN);
 #endif /* BYTECODE_REDUCE_REF */

--- a/src/execute.c
+++ b/src/execute.c
@@ -3188,10 +3188,22 @@ bf_set_live_profiling(Var arglist, Byte next, void *vdata, Objid progr)
 void
 register_execute(void)
 {
-    register_function_with_read_write("call_function", 1, -1, bf_call_function,
+    /*
+     * WARN: register_function* may return 0 if there are too many functions,
+     * but 0 is also a valid function number, and we don't have a good way to
+     * differentiate them.
+     *
+     * If there are too many functions, this may accidentally set the first
+     * function to require builtin variables.
+     */
+    unsigned func_id;
+    func_id = register_function_with_read_write("call_function", 1, -1, bf_call_function,
 				      bf_call_function_read,
 				      bf_call_function_write,
 				      TYPE_STR);
+    /* call_function may call other builtins that need builtin variables. */
+    set_bi_function_requires_bi_variables(func_id, 1);
+
     register_function("raise", 1, 3, bf_raise, TYPE_ANY, TYPE_STR, TYPE_ANY);
     register_function("suspend", 0, 1, bf_suspend, TYPE_NUMERIC);
     register_function("read", 0, 2, bf_read, TYPE_OBJ, TYPE_ANY);
@@ -3200,10 +3212,18 @@ register_execute(void)
     register_function("ticks_left", 0, 0, bf_ticks_left);
     register_function("cputime", 0, 0, bf_cputime);
     register_function("pass", 0, -1, bf_pass);
-    register_function("call_verb", 3, 4, bf_call_verb,
-	TYPE_OBJ, TYPE_STR, TYPE_LIST, TYPE_OBJ);
-    register_function("call_verb_index", 4, 6, bf_call_verb_index,
+
+    /*
+     * Both call_verb* functions need builtin variables such as dobj to be
+     * preserved.
+     */
+    func_id = register_function("call_verb", 3, 4, bf_call_verb,
+        TYPE_OBJ, TYPE_STR, TYPE_LIST, TYPE_OBJ);
+    set_bi_function_requires_bi_variables(func_id, 1);
+    func_id = register_function("call_verb_index", 4, 6, bf_call_verb_index,
         TYPE_OBJ, TYPE_INT, TYPE_STR, TYPE_LIST, TYPE_OBJ, TYPE_OBJ);
+    set_bi_function_requires_bi_variables(func_id, 1);
+
     register_function("set_task_perms", 1, 1, bf_set_task_perms, TYPE_OBJ);
     register_function("caller_perms", 0, 0, bf_caller_perms);
     register_function("callers", 0, 1, bf_callers, TYPE_ANY);

--- a/src/functions.c
+++ b/src/functions.c
@@ -85,6 +85,7 @@ struct bft_entry {
     bf_read_type read;
     bf_write_type write;
     int protected;
+    int require_builtin_variables;
 };
 
 static struct bft_entry bf_table[MAX_FUNC];
@@ -116,6 +117,7 @@ register_common(const char *name, int minargs, int maxargs, bf_type func,
     bf_table[top_bf_table].read = read;
     bf_table[top_bf_table].write = write;
     bf_table[top_bf_table].protected = 0;
+    bf_table[top_bf_table].require_builtin_variables = 0;
 
     if (num_arg_types > 0)
 	bf_table[top_bf_table].prototype =
@@ -153,6 +155,39 @@ register_function_with_read_write(const char *name, int minargs, int maxargs,
     ans = register_common(name, minargs, maxargs, func, read, write, args);
     va_end(args);
     return ans;
+}
+
+/*
+ * Set whether the given builtin function may need builtin variables for
+ * bytecode reference reduction.
+ */
+unsigned
+set_bi_function_requires_bi_variables(unsigned n, int require_bi_variables)
+{
+    if (n >= top_bf_table) {
+        return FUNC_NOT_FOUND;
+    } else {
+        bf_table[n].require_builtin_variables = require_bi_variables;
+        return n;
+    }
+}
+
+/*
+ * Check whether the given builtin function may need builtin variables for
+ * bytecode reference reduction.
+ */
+int
+bi_function_requires_bi_variables(unsigned n)
+{
+    if (n >= top_bf_table) {
+        errlog("bi_function_requires_bi_variables: Unknown function number: %d\n", n);
+        /* We shouldn't get here since this is used by codegen and should only
+         * be using functions it's already looked up anyway.
+         */
+        return 0;
+    } else {
+        return bf_table[n].require_builtin_variables;
+    }
 }
 
 /*** looking up functions -- by name or num ***/

--- a/src/functions.h
+++ b/src/functions.h
@@ -79,6 +79,19 @@ extern unsigned register_function_with_read_write(const char *, int, int,
 						  bf_type, bf_read_type,
 						  bf_write_type,...);
 
+/*
+ * Set whether the given builtin function may need builtin variables for
+ * bytecode reference reduction.
+ */
+extern unsigned set_bi_function_requires_bi_variables(unsigned n,
+        int require_bi_variables);
+
+/*
+ * Check whether the given builtin function may need builtin variables for
+ * bytecode reference reduction.
+ */
+extern int bi_function_requires_bi_variables(unsigned n);
+
 extern package call_bi_func(unsigned, Var, Byte, Objid, void *);
 /* will free or use Var arglist */
 


### PR DESCRIPTION
# Overview

Both the `call_verb()` and `call_verb_index()` builtin functions, specific to HellCore, have a particular bug that has existed as long as they have, but which required specific circumstances to trigger.

# Explanation

When generating the opcodes for a given verb, if the `BYTECODE_REDUCE_REF` optimization is enabled, `PUSH_CLEAR` opcodes may be generated instead of `PUSH` opcodes.

From what I can tell, `PUSH_CLEAR` is an optimization essentially allowing whatever operation ends up using the value it pushes to take over the entire value, rather than just a reference to it, thus reducing reference overhead.

However, `PUSH_CLEAR` can naturally only be used for the very last time a variable is used, such as a variable which is not used later in the given verb.

The code within `stmt_to_code()` attempts to read backwards to find the last usage of each variable, and replace the last `PUSH` with a `PUSH_CLEAR` for this optimization.

However, several exceptions are made, most relevantly, if `OP_CALL_VERB` happens later, i.e. a verb is called later in the code, all bytecode generated for that block before that point must preserve `argstr`, `dobj`, etc. and not generate `PUSH_CLEAR` opcodes for them.

This ensures, for example, that `dobj` still exists by the time `OP_CALL_VERB` is evaluated later on, as called verbs implicitly need all of the builtin variables.

However, `call_verb()` and `call_verb_index()` also call other verbs, which require these same builtins.

## Example

Consider the following verb:

```
incorrectly_cleared_dobj = dobj;
validly_cleared_args = args;
call_verb(this, "name", {}, this);
```

### Broken Example

Before this change, this generates the following bytecode:

```
Language version number: 6
First line number: 1

Main code vector:
=================
[Bytes for labels = 1, literals = 1, forks = 1, variables = 1, stack refs = 1]
[Maximum stack size = 2]
  0: 111                   PUSH_CLEAR dobj
  1: 054                 * PUT incorrectly_cleared_dobj
  2: 144                   POP
  3: 109                   PUSH_CLEAR args
  4: 055                 * PUT validly_cleared_args
  5: 144                   POP
  6: 073                   PUSH this
  7: 016                 * MAKE_SINGLETON_LIST
  8: 133 000               PUSH_LITERAL "name"
 10: 135                   LIST_ADD_TAIL
 11: 134                   MAKE_EMPTY_LIST
 12: 135                   LIST_ADD_TAIL
 13: 106                   PUSH_CLEAR this
 14: 135                   LIST_ADD_TAIL
 15: 012 013             * CALL_FUNC call_verb
 17: 144                   POP
 18: 143                   DONE
```

If the called verb, in this case `this:name()` uses `dobj`, a rather confusing `Variable Not Found` will be raised when attempting to access `dobj` in the called verb, or any verb which it calls.

This can be difficult and confusing to trigger in practice, as it will only happen if a `PUSH_CLEAR` opcode is generated with a builtin variable which is used at some point during the called verb, and can be prevented by any number of additions to the code, such as:

```
incorrectly_cleared_dobj = dobj;
validly_cleared_args = args;
if (0)
  this:name();
endif
call_verb(this, "name", {}, this);
```

As such changes do not seem like they should cause any change to how the verb functions, this was not a particularly clear problem.

### Working Example

With these changes, this bytecode is instead generated:

```
Language version number: 6
First line number: 1

Main code vector:
=================
[Bytes for labels = 1, literals = 1, forks = 1, variables = 1, stack refs = 1]
[Maximum stack size = 2]
  0: 078                   PUSH dobj
  1: 054                 * PUT incorrectly_cleared_dobj
  2: 144                   POP
  3: 109                   PUSH_CLEAR args
  4: 055                 * PUT validly_cleared_args
  5: 144                   POP
  6: 073                   PUSH this
  7: 016                 * MAKE_SINGLETON_LIST
  8: 133 000               PUSH_LITERAL "name"
 10: 135                   LIST_ADD_TAIL
 11: 134                   MAKE_EMPTY_LIST
 12: 135                   LIST_ADD_TAIL
 13: 106                   PUSH_CLEAR this
 14: 135                   LIST_ADD_TAIL
 15: 012 013             * CALL_FUNC call_verb
 17: 144                   POP
 18: 143                   DONE
```

The only difference is that the `PUSH_CLEAR dobj` is kept as `PUSH dobj`, preserving `dobj` for the call later.

This only keeps it as such if `call_verb`, `call_verb_index`, or `call_function` (which can call either of those) occurs later, and if there are no verb calls, whether directly or by builtin, the optimization is allowed to clear builtin variables, and is still allowed to optimize other variables.

# Notes

I tried to keep this as clean as possible, and extensible to any future builtins with similar requirements.

Notably, `call_verb()` is not in lambdamoo, so this is a HellCore-specific problem.

Additionally, since `call_verb()` and the much newer `call_verb_index()` are used in only a handful of places, very few verbs are in practice affected by this.

One notable concern is that this does change the bytecode generated for verbs slightly, which generally can cause issues with suspended tasks.

However, this will only change the bytecode of verbs containing `call_verb()`, `call_verb_index()`, and `call_function()`, which are only a handful of verbs in the databases I have access to.

The layout of the bytecode is also the same, with a single opcode changed to an opcode with the same arguments taking up the same space.

This should hopefully mean that tasks should generally resume none the wiser, although it is something to keep in mind when updating.